### PR TITLE
Removed redundant if clause in getAutoClass()

### DIFF
--- a/phpfastcache/3.0.0/phpfastcache.php
+++ b/phpfastcache/3.0.0/phpfastcache.php
@@ -112,10 +112,7 @@ class phpFastCache {
         $path = self::getPath(false,$config);
         if(is_writeable($path)) {
             $driver = "files";
-        }else if(extension_loaded('pdo_sqlite') && is_writeable($path)) {
-            $driver = "sqlite";
-        }else if(extension_loaded('apc') && ini_get('apc.enabled') && strpos(PHP_SAPI,"CGI") === false)
-        {
+        }else if(extension_loaded('apc') && ini_get('apc.enabled') && strpos(PHP_SAPI,"CGI") === false) {
             $driver = "apc";
         }else if(class_exists("memcached")) {
             $driver = "memcached";


### PR DESCRIPTION
The clause `else if(extension_loaded('pdo_sqlite') && is_writeable($path))` is redundant, because this code path is only executed, if $path is not writeable. So the right part of that and expression is always false and thus the driver will never be set to sqlite.

Additionally #57 claims, that sqlite is a lot slower than files so there is no point in preferring this driver over files by default.