### PR TITLE
Correcting comparisons with Booleans so they use identical operators.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Code Climate](https://codeclimate.com/github/khoaofgod/phpfastcache/badges/gpa.svg)](https://codeclimate.com/github/khoaofgod/phpfastcache)
+
 ---------------------------
 Simple Yet Powerful PHP Caching Class
 ---------------------------

--- a/example2.php
+++ b/example2.php
@@ -11,7 +11,7 @@ require_once("phpfastcache.php");
 // simple Caching with:
 $cache = phpFastCache("redis");
 
-if($cache->fallback == true) {
+if($cache->fallback === true) {
 	echo " USE BACK UP DRIVER = ".phpFastCache::$config['fallback']." <br>";
 } else {
 	echo ' DRIVER IS GOOD <br>';

--- a/examples/6.cache_whole_website.php
+++ b/examples/6.cache_whole_website.php
@@ -33,12 +33,12 @@ if(isset($_GET['somevar']) && $_GET['somevar'] == "something") {
 
 // No caching for logined user
 // can use with $_COOKIE AND $_SESSION
-if(isset($_SESSION) && $_SESSION['logined'] == true) {
+if(isset($_SESSION) && $_SESSION['logined'] === true) {
     $caching = false;
 }
 
 // ONLY ACCESS CACHE IF $CACHE = TRUE
-if($caching == true ) {
+if($caching === true ) {
     $html = __c("files")->get($keyword_webpage);
 }
 


### PR DESCRIPTION
It's a good idea to always use the identical operator (http://php.net/manual/en/language.operators.comparison.php) when comparing Booleans, so I converted the comparison operators. I ran the codebase through Code Climate (which is how I found the comparison operator instances), so I also added the Code Climate badge to the readme as well. 