### PR TITLE
Fix expiration timer for memcache

### DIFF
--- a/phpfastcache/3.0.0/drivers/memcache.php
+++ b/phpfastcache/3.0.0/drivers/memcache.php
@@ -64,6 +64,12 @@ class phpfastcache_memcache extends BasePhpFastCache implements phpfastcache_dri
     function driver_set($keyword, $value = "", $time = 300, $option = array() ) {
 	    $this->connectServer();
 
+            // Memcache will only allow a expiration timer less than 2592000 seconds,
+            // otherwise, it will assume you're giving it a UNIX timestamp.
+            if($time>2592000) {
+                $time = time()+$time;
+            }
+            
 	    if(isset($option['skipExisting']) && $option['skipExisting'] == true) {
 		    return $this->instant->add($keyword, $value, false, $time );
 


### PR DESCRIPTION
Memcache will only allow a expiration timer less than 2592000 seconds,
otherwise, it will assume you're giving it a UNIX timestamp.