### PR TITLE
Improved stats function for files driver (with PHP 5.3 fix)

### DIFF
--- a/phpfastcache/3.0.0/drivers/files.php
+++ b/phpfastcache/3.0.0/drivers/files.php
@@ -143,6 +143,7 @@ class phpfastcache_files extends  BasePhpFastCache implements phpfastcache_drive
 
         $total = 0;
         $removed = 0;
+        $content = array();
         while($file=@readdir($dir)) {
             if($file!="." && $file!=".." && is_dir($path."/".$file)) {
                 // read sub dir
@@ -156,6 +157,16 @@ class phpfastcache_files extends  BasePhpFastCache implements phpfastcache_drive
                         $file_path = $path."/".$file."/".$f;
                         $size = @filesize($file_path);
                         $object = $this->decode($this->readfile($file_path));
+
+                        if(strpos($f,".") === false) {
+                            $key = $f;
+                        }
+                        else {
+                            //Because PHP 5.3, this cannot be written in single line
+                            $key = explode(".", $f);
+                            $key = $key[0];
+                        }
+                        $content[$key] = array("size"=>$size,"write_time"=>$object["write_time"]);
                         if($this->isExpired($object)) {
                             @unlink($file_path);
                             $removed += $size;
@@ -172,6 +183,7 @@ class phpfastcache_files extends  BasePhpFastCache implements phpfastcache_drive
                 "Expired and removed [bytes]" => $removed,
                 "Current [bytes]" => $res['size'],
        );
+        $res["data"] = $content;
        return $res;
     }
 

--- a/phpfastcache/3.0.0/drivers/files.php
+++ b/phpfastcache/3.0.0/drivers/files.php
@@ -143,7 +143,6 @@ class phpfastcache_files extends  BasePhpFastCache implements phpfastcache_drive
 
         $total = 0;
         $removed = 0;
-        $content = array();
         while($file=@readdir($dir)) {
             if($file!="." && $file!=".." && is_dir($path."/".$file)) {
                 // read sub dir
@@ -157,16 +156,6 @@ class phpfastcache_files extends  BasePhpFastCache implements phpfastcache_drive
                         $file_path = $path."/".$file."/".$f;
                         $size = @filesize($file_path);
                         $object = $this->decode($this->readfile($file_path));
-
-                        if(strpos($f,".") === false) {
-                            $key = $f;
-                        }
-                        else {
-                            //Because PHP 5.3, this cannot be written in single line
-                            $key = explode(".", $f);
-                            $key = $key[0];
-                        }
-                        $content[$key] = array("size"=>$size,"write_time"=>$object["write_time"]);
                         if($this->isExpired($object)) {
                             @unlink($file_path);
                             $removed += $size;
@@ -183,7 +172,6 @@ class phpfastcache_files extends  BasePhpFastCache implements phpfastcache_drive
                 "Expired and removed [bytes]" => $removed,
                 "Current [bytes]" => $res['size'],
        );
-        $res["data"] = $content;
        return $res;
     }
 

--- a/phpfastcache/3.0.0/drivers/files.php
+++ b/phpfastcache/3.0.0/drivers/files.php
@@ -162,7 +162,9 @@ class phpfastcache_files extends  BasePhpFastCache implements phpfastcache_drive
                             $key = $f;
                         }
                         else {
-                            $key = explode(".", $f)[0];
+                            //Because PHP 5.3, this cannot be written in single line
+                            $key = explode(".", $f);
+                            $key = $key[0];
                         }
                         $content[$key] = array("size"=>$size,"write_time"=>$object["write_time"]);
                         if($this->isExpired($object)) {


### PR DESCRIPTION
Improved stats function for files driver. Before data property was empty, now it contains array of all keys in cache with each holding array of size and write time.

Also now with PHP 5.3 fix