### PR TITLE
Modify File Driver to Prevent Partial Reads

### DIFF
--- a/phpfastcache/3.0.0/abstract.php
+++ b/phpfastcache/3.0.0/abstract.php
@@ -280,9 +280,13 @@ abstract class BasePhpFastCache {
                 throw new Exception("Can't Read File",96);
 
             }
-            while (!feof($file_handle)) {
-                $line = fgets($file_handle);
-                $string .= $line;
+            if (flock($file_handle, LOCK_SH | LOCK_NB)) {
+                while (!feof($file_handle)) {
+                    $line = fgets($file_handle);
+                    $string .= $line;
+                }
+            } else {
+                throw new Exception("Can't Read File",96);
             }
             fclose($file_handle);
 

--- a/phpfastcache/3.0.0/drivers/files.php
+++ b/phpfastcache/3.0.0/drivers/files.php
@@ -88,8 +88,14 @@ class phpfastcache_files extends  BasePhpFastCache implements phpfastcache_drive
 
         if($toWrite == true) {
                 try {
-                    $f = @fopen($file_path, "w+");
-                    fwrite($f, $data);
+                    $f = @fopen($file_path, "c");
+                    if (flock($f,LOCK_EX| LOCK_NB))  { //got a lock to write;
+                        fwrite($f, $data);
+                        fflush($f);
+                        flock($f,LOCK_UN);
+                    } else {
+                        //arguably the file is being written to so the job is done
+                    }
                     fclose($f);
                 } catch (Exception $e) {
                     // miss cache


### PR DESCRIPTION
The file driver currently opens files for writing in a mode which allows other cache readers to read while writes are being performed.