### PR TITLE
Remove race by journaling writes; misc

### DIFF
--- a/phpfastcache/3.0.0/abstract.php
+++ b/phpfastcache/3.0.0/abstract.php
@@ -280,9 +280,13 @@ abstract class BasePhpFastCache {
                 throw new Exception("Can't Read File",96);
 
             }
+            if (flock($file_handle, LOCK_SH | LOCK_NB)) {
             while (!feof($file_handle)) {
                 $line = fgets($file_handle);
                 $string .= $line;
+            }
+            } else {
+                throw new Exception("Can't Read File",96);
             }
             fclose($file_handle);
 

--- a/phpfastcache/3.0.0/phpfastcache.php
+++ b/phpfastcache/3.0.0/phpfastcache.php
@@ -159,7 +159,7 @@ class phpFastCache {
             $path = $config['path'];
         }
 
-        $securityKey = $config['securityKey'];
+        $securityKey = array_key_exists('securityKey',$config) ? $config['securityKey'] : "";
         if($securityKey == "" || $securityKey == "auto") {
             $securityKey = self::$config['securityKey'];
             if($securityKey == "auto" || $securityKey == "") {
@@ -193,7 +193,7 @@ class phpFastCache {
 
 
             self::$tmp[$full_pathx] = true;
-            self::htaccessGen($full_path, $config['htaccess']);
+            self::htaccessGen($full_path, array_key_exists('htaccess',$config) ? $config['htaccess'] : false);
         }
 
         return realpath($full_path);


### PR DESCRIPTION
1. files.php: This updates the previous patch (using flock()) to avoid a race when readers attempt to open the file between the fopen() call and the flock(). 
2. files.php: Now the writer writes the file to $file_path . ".tmp", so no read can occur. Multiple attempts to write will result in the first-writer winning
3. files.php: When writing is complete, the writer pivots (via rename()) the tmp file into the final location (one assumes rename is atomic and instantaneous; I'm sure some FS will prove me wrong)
4. phpfastcache.php: added array_key_exists(<key>,<array) checks to uninitialized access to $config