### PR TITLE
Modify "mkdir()" to be multi-writer safe

### DIFF
--- a/phpfastcache/3.0.0/abstract.php
+++ b/phpfastcache/3.0.0/abstract.php
@@ -270,9 +270,6 @@ abstract class BasePhpFastCache {
 
 
     protected function readfile($file) {
-        if(function_exists("file_get_contents")) {
-            return @file_get_contents($file);
-        } else {
             $string = "";
 
             $file_handle = @fopen($file, "r");
@@ -291,7 +288,6 @@ abstract class BasePhpFastCache {
             fclose($file_handle);
 
             return $string;
-        }
     }
 
 

--- a/phpfastcache/3.0.0/abstract.php
+++ b/phpfastcache/3.0.0/abstract.php
@@ -270,6 +270,9 @@ abstract class BasePhpFastCache {
 
 
     protected function readfile($file) {
+        if(function_exists("file_get_contents")) {
+            return @file_get_contents($file);
+        } else {
             $string = "";
 
             $file_handle = @fopen($file, "r");
@@ -277,17 +280,14 @@ abstract class BasePhpFastCache {
                 throw new Exception("Can't Read File",96);
 
             }
-            if (flock($file_handle, LOCK_SH | LOCK_NB)) {
-                while (!feof($file_handle)) {
-                    $line = fgets($file_handle);
-                    $string .= $line;
-                }
-            } else {
-                throw new Exception("Can't Read File",96);
+            while (!feof($file_handle)) {
+                $line = fgets($file_handle);
+                $string .= $line;
             }
             fclose($file_handle);
 
             return $string;
+        }
     }
 
 

--- a/phpfastcache/3.0.0/drivers/files.php
+++ b/phpfastcache/3.0.0/drivers/files.php
@@ -52,15 +52,13 @@ class phpfastcache_files extends  BasePhpFastCache implements phpfastcache_drive
          * Skip Create Sub Folders;
          */
         if($skip == false) {
-            if(!@file_exists($path)) {
-                if(!@mkdir($path,$this->__setChmodAuto())) {
+            //if it doesn't exist, I can't create it, and nobody beat me to creating it:
+            if(!@is_dir($path) && !@mkdir($path,$this->__setChmodAuto()) && !@is_dir($path)) {
                     throw new Exception("PLEASE CHMOD ".$this->getPath()." - 0777 OR ANY WRITABLE PERMISSION!",92);
-                }
-
-            } elseif(!is_writeable($path)) {
-                if(!chmod($path,$this->__setChmodAuto())) {
+            }
+            //if it does exist (after someone beat me to it, perhaps), but isn't writable or fixable:
+            if(@is_dir($path) && !is_writeable($path) && !@chmod($path,$this->__setChmodAuto())) {
                     throw new Exception("PLEASE CHMOD ".$this->getPath()." - 0777 OR ANY WRITABLE PERMISSION!",92);
-                }
             }
         }
 


### PR DESCRIPTION
1. files.php: Switched file_exists() to is_dir() for checks on the intermediate $path
2. files.php: Modified getFilePath() to continue normally if another file-writer creates the directory successfully between calls to is_dir() and mkdir()
3. Reverted abstract.php because locking reads aren't necessary with "journaled" writes.
