### PR TITLE
Bug Fixes in file writing and dir naming.

### DIFF
--- a/phpfastcache/3.0.0/drivers/files.php
+++ b/phpfastcache/3.0.0/drivers/files.php
@@ -91,7 +91,7 @@ class phpfastcache_files extends  BasePhpFastCache implements phpfastcache_drive
          * because first-to-lock wins and the file will exist before the writer attempts
          * to write.
          */
-        if($toWrite == true && !@file_exists($tmp_path && !@file_exists($file_path))) {
+        if($toWrite == true && !@file_exists($tmp_path) && !@file_exists($file_path)) {
                 try {
                     $f = @fopen($tmp_path, "c");
                     if ($f) {

--- a/phpfastcache/3.0.0/phpfastcache.php
+++ b/phpfastcache/3.0.0/phpfastcache.php
@@ -163,13 +163,14 @@ class phpFastCache {
         if($securityKey == "" || $securityKey == "auto") {
             $securityKey = self::$config['securityKey'];
             if($securityKey == "auto" || $securityKey == "") {
-                $securityKey = isset($_SERVER['HTTP_HOST']) ? ltrim(strtolower($_SERVER['HTTP_HOST']),"www.") : "default";
-                $securityKey = preg_replace("/[^a-zA-Z0-9]+/","",$securityKey);
+                $securityKey = isset($_SERVER['HTTP_HOST']) ? preg_replace('/^www./','',strtolower($_SERVER['HTTP_HOST'])) : "default";
             }
         }
         if($securityKey != "") {
             $securityKey.= "/";
         }
+        
+        $securityKey = self::cleanFileName($securityKey);
 
         $full_path = $path."/".$securityKey;
         $full_pathx = md5($full_path);
@@ -198,6 +199,12 @@ class phpFastCache {
 
         return realpath($full_path);
 
+    }
+    
+    public static function cleanFileName($filename) {
+        $regex = ['/[\?\[\]\/\\\=\<\>\:\;\,\'\"\&\$\#\*\(\)\|\~\`\!\{\}]/','/\.$/','/^\./'];
+        $replace = ['-','',''];
+        return preg_replace($regex,$replace,$filename);
     }
 
 


### PR DESCRIPTION
files.php: fix file writer bug (misplaced paren ) where no file would… write.
phpfastcache.php: fix error where non-www.domain.tld HOST_NAME variables would be stripped of beginning w's in mistaken ltrim call
phpfastcache.php: move filename fixing into static function that removes common "unsafe" characters and positions ("/name?" or "name.")
TODO: call filename fixer in files.php